### PR TITLE
Config must

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@
 package config
 
 import (
+	"log"
 	"os"
 	"strings"
 )
@@ -65,4 +66,17 @@ func (c *Configuration) Get(key string) (string, bool) {
 	}
 
 	return "", false
+}
+
+// GetMust is a helper that wraps Get and calls log.Fatal if the returned err
+// from Get is non-nil. In that case the program will halt execution and a
+// short message will have been logged explaining why. This is intended to aid
+// in mandatory variable initialization.
+func (c *Configuration) GetMust(key string) string {
+	if val, found := c.Get(key); found {
+		return val
+	} else {
+		log.Fatalf("Unable to retrive %s from config in a must context", key)
+		return "" // Unreachable, log.Fatalf will exit program
+	}
 }

--- a/durn.go
+++ b/durn.go
@@ -16,14 +16,12 @@ import "github.com/gorilla/mux"
 func setupLog() {
 	log.SetFlags(log.Ldate | log.Ltime | log.LUTC)
 
-	if debugMode, found := config.Default.Get("DEBUG_MODE"); found {
-		if b, err := strconv.ParseBool(debugMode); err != nil {
-			log.Fatalf("Config value DEBUG_MODE not a boolean (%s)", debugMode)
-		} else if b {
-			log.SetFlags(log.Flags() | log.Llongfile)
-		}
-	} else {
-		log.Fatalf("Unable to retrive DEBUG_MODE from default config")
+	debugMode := config.Default.GetMust("DEBUG_MODE")
+
+	if b, err := strconv.ParseBool(debugMode); err != nil {
+		log.Fatalf("Config value DEBUG_MODE not a boolean (%s)", debugMode)
+	} else if b {
+		log.SetFlags(log.Flags() | log.Llongfile)
 	}
 
 	log.SetOutput(os.Stdout)
@@ -39,12 +37,7 @@ func createRouter() (router *mux.Router) {
 }
 
 func createServer(r *mux.Router) (srv *http.Server) {
-	var port string
-	if val, exist := config.Default.Get("WEB_PORT"); exist {
-		port = val
-	} else {
-		log.Fatalf("Unable to retrive SERVER_PORT from default config.")
-	}
+	port := config.Default.GetMust("WEB_PORT")
 
 	srv = &http.Server {
 		Handler:      r,


### PR DESCRIPTION
Add `GetMust` versions of `Configuration`'s `Get` method. This is useful for when the server starts and wants to read mandatory config such as port number.