### PR TITLE
Make app deployment compatible

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,7 @@ import (
 // Default is a configuration containing globally useful values.
 var Default = func() *Configuration {
 	def := New(nil, map[string]string{
-		"WEB_PORT": "8080",
+		"PORT": "8080",
 		"DEBUG_MODE": "false",
 		"DEFAULT_SITE_TITLE": "DUrn",
 	})

--- a/durn.go
+++ b/durn.go
@@ -52,11 +52,11 @@ func createRouter(viewFactory view.Factory) (router *mux.Router) {
 }
 
 func createServer(r *mux.Router) (srv *http.Server) {
-	port := config.Default.GetMust("WEB_PORT")
+	port := config.Default.GetMust("PORT")
 
 	srv = &http.Server {
 		Handler:      r,
-		Addr:         fmt.Sprintf("127.0.0.1:%s", port),
+		Addr:         fmt.Sprintf(":%s", port),
 		WriteTimeout: 15 * time.Second,
 		ReadTimeout:  15 * time.Second,
 	}


### PR DESCRIPTION
Change config key for WEB_PORT entry to PORT to be compatible with
Dokku. Also, do not specify what address to bind to.